### PR TITLE
change in infinite slider to display all the companies

### DIFF
--- a/components/achievements/infiniteSlider.jsx
+++ b/components/achievements/infiniteSlider.jsx
@@ -11,25 +11,31 @@ const InfiniteSlider = ({ data, direction }) => {
     }, 1000);
     return () => clearTimeout(delay);
   }, []);
+
+  const moveRight = direction === "right" || direction === true;
+
   return (
-    <div>
+    <div className="w-full flex justify-center items-center">
       {showSlider && (
-        <Slider toRight={direction} blurBoderColor={'black'}>
+        <Slider
+          toRight={moveRight}
+          blurBorderColor="black"
+          duration={90}
+        >
           {data.map((company, index) => (
-            <div className="flex justify-center items-center" key={index}>
-              <Slider.Slide className="">
-                <img
-                  src={company.img_path}
-                  alt={company.alt}
-                  className="md:w-44 md:h-44"
-                />
-              </Slider.Slide>
-            </div>
+            <Slider.Slide key={index}>
+              <img
+                src={company.img_path}
+                alt={company.alt || `company-${index}`}
+                className="md:w-44 md:h-44 object-contain"
+              />
+            </Slider.Slide>
           ))}
         </Slider>
       )}
     </div>
   );
 };
+
 
 export default InfiniteSlider;


### PR DESCRIPTION
This PR fixes the issue where not all company logos were visible or scrolling properly in the alumni section slider.

ISSUE:
react-infinite-logo-slider requires its <Slider.Slide> components to be direct children of <Slider>.
The previous version wrapped them inside an extra <div>, breaking layout and causing missing slides.

Fix: 
Fixed Slider child structure
Normalized direction prop

Before:
<img width="1852" height="923" alt="Screenshot from 2025-11-06 21-39-57" src="https://github.com/user-attachments/assets/8bee1c58-566e-46c6-bc6e-a3f7b9d92762" />


closes #31 