### PR TITLE
Remove placeholder entry from members data

### DIFF
--- a/app/(root)/team/page.jsx
+++ b/app/(root)/team/page.jsx
@@ -25,6 +25,8 @@ const Page = async () => {
   const members = await fetchTeamData(MEMBERS_DATA_URL);
   const alumni = await fetchTeamData(ALUMNI_DATA_URL);
 
+  members.pop();
+
   return (
     <>
       {/* Client Component for the animated header, scroll ref, and hero image */}


### PR DESCRIPTION
Currently, data fetched from member-directory contain an extra entry for merge queue. 
  {
    "ADD_ABOVE_HERE_TO_AVOID_MERGE_CONFLICTS": ""
  }
this entry creates an empty member card in the website.
This PR removes that from members array.