### PR TITLE
Add GitHub issue forms and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,105 @@
+name: "🐞 Bug report"
+description: Create a report to help us improve the web project.
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Before creating an issue, please search the existing issues to see if a similar one already exists.
+        - You can search issues using labels or keywords in the issue search bar.
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Briefly describe the bug and what you expected to happen.
+      placeholder: The submit button does not respond on the login page.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to the homepage
+        2. Click on Login
+        3. Enter valid credentials
+        4. Click Submit
+        5. Observe the issue
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behaviour
+      placeholder: User should be logged in and redirected to the dashboard.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behaviour
+      placeholder: Nothing happens when clicking submit.
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Environment information
+
+  - type: input
+    attributes:
+      label: Affected page / URL
+      placeholder: https://example.com/login
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Firefox
+        - Edge
+        - Safari
+        - Brave
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Operating system
+      placeholder: Ubuntu 22.04 / Windows 11 / macOS Sonoma
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Device type
+      options:
+        - Desktop
+        - Laptop
+        - Tablet
+        - Mobile
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Console errors / logs
+      description: Paste browser console errors (DevTools → Console).
+
+  - type: textarea
+    attributes:
+      label: Screenshots / screen recordings
+
+  - type: dropdown
+    attributes:
+      label: Would you like to work on this issue?
+      options:
+        - "Yes"
+        - Prefer not

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-name: "🐞 Bug report"
+name: "Bug report"
 description: Create a report to help us improve the web project.
 title: "[Bug]: "
 labels: ["bug"]

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,62 @@
+name: "⭐ Feature request"
+description: Suggest an idea or enhancement for this web project
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Please search existing issues before creating a new one to avoid duplicates.
+        - Each issue should describe **one** feature request only.
+        - Feature requests work best when they focus on the **problem**, not a demanded solution.
+          (e.g., “There should be an easier way to do X” instead of “Add Y button”.)
+
+  - type: textarea
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the user problem or growth opportunity.
+      placeholder: Users find it hard to discover recently added content.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Why is this important?
+      description: How do you know this problem exists? Any evidence or examples?
+      placeholder: Users frequently ask about this in discussions / issues.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Who will benefit from this feature?
+      description: Describe the target users or contributors who would benefit.
+      placeholder: New users, contributors, maintainers, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Suggested approach (optional)
+      description: If you have ideas, share them—but avoid being overly prescriptive.
+      placeholder: This could be improved by showing a filter or a quick access section.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Mockups, links, screenshots, or related issues.
+    validations:
+      required: false
+
+  - type: dropdown
+    attributes:
+      label: Would you like to work on this feature?
+      description: Let us know if you want to implement this feature yourself.
+      options:
+        - "Yes"
+        - Prefer not
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,4 +1,4 @@
-name: "⭐ Feature request"
+name: "Feature request"
 description: Suggest an idea or enhancement for this web project
 title: "[Feature]: "
 labels: ["enhancement"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**Description (required)**
+
+Fixes #INSERT_ISSUE_NUMBER_HERE
+
+Briefly describe what changes you made and why they were necessary.
+
+---
+
+**Tests performed (required)**
+
+Describe how you tested your changes.
+
+Example:
+- Tested locally on Chrome / Firefox
+- Verified on desktop and mobile view
+- Checked affected routes/pages
+
+---
+
+**Screenshots (for UI changes only)**
+
+If applicable, add screenshots or screen recordings to help reviewers.
+
+---
+
+_Note: Please ensure that you have read and followed `CONTRIBUTING.md` if this is your first pull request._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@ Briefly describe what changes you made and why they were necessary.
 
 **Tests performed (required)**
 
-Describe how you tested your changes.
+Please check all that apply:
 
-Example:
-- Tested locally on Chrome / Firefox
-- Verified on desktop and mobile view
-- Checked affected routes/pages
+- [ ] Tested locally on Chrome / Firefox
+- [ ] Verified on both desktop and mobile view
+- [ ] Checked affected routes/pages
+- [ ] Not tested (please explain why)
 
 ---
 


### PR DESCRIPTION
This PR adds GitHub issue templates and a pull request template to improve the contribution workflow.

The templates are inspired by a project I contribute to that is Android-focused.  
I updated the templates to align with the current web project structure.

Please let me know if any changes or improvements are needed.

Fixes: #27 
