### PR TITLE
Fixed #22 (edited global.css to hide navbar arrows in smaller screens)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -47,3 +47,10 @@
     box-shadow: 0 0 15px 3px rgba(208, 167, 48, 0.9); /* Increase glow on hover */
   }  
 }
+/* To hide navbar arrows on small screens */
+@media (max-width: 767px) {
+  .react-multiple-carousel__arrow--left,
+  .react-multiple-carousel__arrow--right {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
The right/left navbar arrows  were visible on smaller screens, which overlapped the menu content (mobile devices).

To fix this, the global.css file was modified accordingly by adding a responsive media query that targets smaller screen widths.

On screens below 768px (mobile screens), the navbar arrows are hidden.
But on larger screens (tablet and desktop), the arrows will be visible.