### PR TITLE
fix:see-more issue

### DIFF
--- a/lib/hooks/useResponsiveGrid.js
+++ b/lib/hooks/useResponsiveGrid.js
@@ -28,11 +28,12 @@ export const useResponsiveGrid = (data) => {
   }, [data]);
 
   const toggleMembersVisibility = () => {
-    setShowAllMembers(!showAllMembers);
-    if (showAllMembers) {
-      updateVisibleMembers();
-    } else {
+    const newShowAll = !showAllMembers;
+    setShowAllMembers(newShowAll);
+    if (newShowAll) {
       setVisibleMembers(data);
+    } else {
+      updateVisibleMembers();
     }
   };
 


### PR DESCRIPTION
**Description (required)**

There is some problem with see more issue in the team page which shut downs when we do a little fast scroll after clicking see more 


---

**Tests performed (required)**

Please check all that apply:

- [x] Tested locally on Chrome / Firefox
- [x] Verified on both desktop and mobile view
- [ ] Checked affected routes/pages
- [ ] Not tested (please explain why)

---

_Note: Please ensure that you have read and followed `CONTRIBUTING.md` if this is your first pull request._
