### PR TITLE
fix: correct md:h-[350rem] to reasonable image container height

### DIFF
--- a/app/(root)/team/[slug]/page.jsx
+++ b/app/(root)/team/[slug]/page.jsx
@@ -61,7 +61,7 @@ export default async function Page({ params }) {
 
       <div className="mt-8 grid lg:grid-cols-2 gap-8 items-start">
         <div className="rounded-2xl overflow-hidden bg-slate-950/70 shadow-lg">
-          <div className="relative h-[30rem] md:h-[350rem] lg:h-[40rem]">
+          <div className="relative h-[30rem] md:h-[29rem] lg:h-[40rem]">
             <Image
               src={imgSrc}
               alt={member.name}


### PR DESCRIPTION
In my previous PR #45, `md:h-[350rem]` was a typo that caused the member images on medium screens to appear tooo large. The value has been corrected, now it fits perfectly and makes the layout responsive.