### PR TITLE
Fix broken icon paths

### DIFF
--- a/content/socials.json
+++ b/content/socials.json
@@ -1,17 +1,17 @@
 [
   {
     "title": "Github",
-    "image": "./assets/icons/socials/Vector.svg",
+    "image": "/assets/icons/socials/Vector.svg",
     "ref": "https://github.com/amfoss"
   },
   {
     "title": "X",
-    "image": "./assets/icons/socials/Vector-2.svg",
+    "image": "/assets/icons/socials/Vector-2.svg",
     "ref": "https://twitter.com/amfoss_in"
   },
   {
     "title": "Gitlab",
-    "image": "./assets/icons/socials/Vector-1.svg",
+    "image": "/assets/icons/socials/Vector-1.svg",
     "ref": "https://gitlab.com/amfoss"
   }
 ]


### PR DESCRIPTION
Rn in the website, when navigating to an individual member page (e.g., https://amfoss.in/team/k-k-surendran) and reloading it, the icons fail to load correctly. The issue was caused by broken relative asset paths. Fixed by switching to absolute asset paths so that icons render properly on reload.